### PR TITLE
New small fixes and features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project will be documented in this file.
 - JOhm.setPool returns JedisPool instead of void - so it can be used as factory-method for Spring Dependency Injection
 - BREAKING CHANGE - JOhm.getAll is no longer supported by default - you have to add an explicit annotation to the model: [@SupportAll](src/main/java/redis/clients/johm/SupportAll.java)
 - HA - Add Sentinel support - task #6 - now you can connect to Redis HA cluster via Redis sentinels and use JOhm with HA!
+- fix NULL values for BigDecimal and BigInteger
+- save - if not new - propagate deleteChildren flag and deleteIndexes=true
+- added expireIndexes support - with an overloaded method "expire"
+- jedis bump to 2.8.0 because of slow Apache Commons Pool (BaseGenericObjectPool - updateStatsReturn and updateStatsBorrow)
+
 
 ### Added
 - Expire support: JOhm.expire(model, seconds)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,12 @@ All notable changes to this project will be documented in this file.
 - HA - Add Sentinel support - task #6 - now you can connect to Redis HA cluster via Redis sentinels and use JOhm with HA!
 - fix NULL values for BigDecimal and BigInteger
 - save - if not new - propagate deleteChildren flag and deleteIndexes=true
-- added expireIndexes support - with an overloaded method "expire"
 - jedis bump to 2.8.0 because of slow Apache Commons Pool (BaseGenericObjectPool - updateStatsReturn and updateStatsBorrow)
 
 
 ### Added
 - Expire support: JOhm.expire(model, seconds)
+- added expireIndexes support - with an overloaded method "expire"
 
 ## [0.6.5] - 2016-04-25
 ### Added

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 		<dependency>
 			<groupId>redis.clients</groupId>
 			<artifactId>jedis</artifactId>
-            <version>2.7.0</version>
+            <version>2.8.0</version>
 			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>

--- a/src/main/java/redis/clients/johm/JOhm.java
+++ b/src/main/java/redis/clients/johm/JOhm.java
@@ -227,7 +227,7 @@ public final class JOhm {
 	@SuppressWarnings("unchecked")
 	public static <T> T save(final Object model, boolean saveChildren) {
 		if (!isNew(model)) {
-			delete(model.getClass(), JOhmUtils.getId(model));
+			delete(model.getClass(), JOhmUtils.getId(model), true, saveChildren);
 		}
 		final Nest nest = initIfNeeded(model);
 

--- a/src/main/java/redis/clients/johm/JOhm.java
+++ b/src/main/java/redis/clients/johm/JOhm.java
@@ -357,7 +357,46 @@ public final class JOhm {
      * @return Long
      */
     public static <T> Long expire(T model, int seconds) {
+        return expire(model, seconds, false);
+    }
+    
+    /**
+     * Set expiration period of model and indexes (optionally)
+     * @param <T>
+     * @param model
+     * @param seconds
+     * @param expireIndexes should indexes expire
+     * @return Long
+     */
+    public static <T> Long expire(T model, int seconds, boolean expireIndexes) {
         Nest<T> nest = initIfNeeded(model);
+        
+        if (expireIndexes) {
+            // think about promoting deleteChildren as default behavior so
+            // that this field lookup gets folded into that
+            // if-deleteChildren block
+            for (Field field : JOhmUtils.gatherAllFields(model.getClass())) {
+                if (field.isAnnotationPresent(Indexed.class)) {
+                    field.setAccessible(true);
+                    Object fieldValue = null;
+                    try {
+                        fieldValue = field.get(model);
+                    } catch (IllegalArgumentException e) {
+                        throw new JOhmException(e);
+                    } catch (IllegalAccessException e) {
+                        throw new JOhmException(e);
+                    }
+                    if (fieldValue != null
+                            && field.isAnnotationPresent(Reference.class)) {
+                        fieldValue = JOhmUtils.getId(fieldValue);
+                    }
+                    if (!JOhmUtils.isNullOrEmpty(fieldValue)) {
+                        nest.cat(field.getName()).cat(fieldValue).expire(seconds);
+                    }
+                }
+            }
+        }
+        
         return nest.cat(JOhmUtils.getId(model)).expire(seconds);
     }
 

--- a/src/main/java/redis/clients/johm/JOhmUtils.java
+++ b/src/main/java/redis/clients/johm/JOhmUtils.java
@@ -266,9 +266,11 @@ public final class JOhmUtils {
 
             // Higher precision folks
             if (type.equals(BigDecimal.class)) {
+                if (value == null) return BigDecimal.ZERO;
                 return new BigDecimal(value);
             }
             if (type.equals(BigInteger.class)) {
+                if (value == null) return BigInteger.ZERO;
                 return new BigInteger(value);
             }
 

--- a/src/test/java/redis/clients/johm/ConvertorTest.java
+++ b/src/test/java/redis/clients/johm/ConvertorTest.java
@@ -201,7 +201,7 @@ public class ConvertorTest extends Assert {
         converted = JOhmUtils.Convertor.convert(BigDecimal.class, value);
         assertTrue(converted.getClass().equals(BigDecimal.class));
         assertEquals(BigDecimal.valueOf(-10.999d), converted);
-
+        
         // biginteger
         value = "-10999";
         converted = JOhmUtils.Convertor.convert(BigInteger.class, value);
@@ -236,5 +236,65 @@ public class ConvertorTest extends Assert {
 
         converted = JOhmUtils.Convertor.convert(Collection.class, value);
         assertNull(converted);
+    }
+    
+    @Test
+    public void testNullValues() {
+        String value = null;
+        Object converted = null;
+        
+        // int NULL
+        value = null;
+        converted = JOhmUtils.Convertor.convert(Integer.class, value);
+        assertTrue(converted.getClass().equals(Integer.class));
+        assertEquals(Integer.valueOf("0"), converted);
+
+        converted = JOhmUtils.Convertor.convert(int.class, value);
+        assertTrue(converted.getClass().equals(Integer.class));
+        assertEquals(Integer.valueOf("0"), converted);
+
+        // float NULL
+        value = null;
+        converted = JOhmUtils.Convertor.convert(Float.class, value);
+        assertTrue(converted.getClass().equals(Float.class));
+        assertEquals(Float.valueOf("0"), converted);
+
+        converted = JOhmUtils.Convertor.convert(float.class, value);
+        assertTrue(converted.getClass().equals(Float.class));
+        assertEquals(Float.valueOf("0"), converted);
+
+        // double NULL
+        value = null;
+        converted = JOhmUtils.Convertor.convert(Double.class, value);
+        assertTrue(converted.getClass().equals(Double.class));
+        assertEquals(Double.valueOf("0"), converted);
+
+        converted = JOhmUtils.Convertor.convert(double.class, value);
+        assertTrue(converted.getClass().equals(Double.class));
+        assertEquals(Double.valueOf("0"), converted);
+
+        // long NULL
+        value = null;
+        converted = JOhmUtils.Convertor.convert(Long.class, value);
+        assertTrue(converted.getClass().equals(Long.class));
+        assertEquals(Long.valueOf("0"), converted);
+
+        converted = JOhmUtils.Convertor.convert(long.class, value);
+        assertTrue(converted.getClass().equals(Long.class));
+        assertEquals(Long.valueOf("0"), converted);
+
+        
+        // bigdecimal NULL
+        value = null;
+        converted = JOhmUtils.Convertor.convert(BigDecimal.class, value);
+        assertTrue(converted.getClass().equals(BigDecimal.class));
+        assertEquals(BigDecimal.valueOf(0), converted);
+        
+        // biginteger NULL
+        value = null;
+        converted = JOhmUtils.Convertor.convert(BigInteger.class, value);
+        assertTrue(converted.getClass().equals(BigInteger.class));
+        assertEquals(BigInteger.valueOf(0), converted);
+        
     }
 }


### PR DESCRIPTION
- fix NULL values for BigDecimal and BigInteger
- save - if not new - propagate deleteChildren flag and deleteIndexes=true
- added expireIndexes support - with an overloaded method "expire"
- jedis bump to 2.8.0 because of slow Apache Commons Pool (BaseGenericObjectPool - updateStatsReturn and updateStatsBorrow)